### PR TITLE
chore: remove unused Note import

### DIFF
--- a/src/insight/signals.ts
+++ b/src/insight/signals.ts
@@ -1,5 +1,3 @@
-import type { Note } from '../types';
-
 const tokenize = (s:string) => s.toLowerCase().replace(/[^a-z0-9\u4e00-\u9fa5\s]/g,' ').split(/\s+/).filter(Boolean);
 
 export type Signals = {


### PR DESCRIPTION
## Summary
- drop unused `Note` type import from insight signals module
- tidy file header

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'https://esm.sh/pdfjs-dist@4.5.136', Property 'map' does not exist on type 'unknown', Object literal may only specify known properties, and more)*
- `npx tsc --noEmit --target ES2022 --moduleResolution bundler src/insight/signals.ts`


------
https://chatgpt.com/codex/tasks/task_b_68a679ad58648328b3a8d8a69c4496e9