### PR TITLE
Use estimated LLM call count in metrics logging

### DIFF
--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -522,7 +522,7 @@ export const findSynapticLink = async (
                 tier,
                 depthCycles: cycle,
                 tokensEstimated: est.tokens,
-                llmCalls: candNotes.length,
+                llmCalls: est.llmCalls,
                 candidateNotes: candNotes.length,
                 evidenceSnippets: topResult?.evidenceRefs.length ?? 0,
                 signals: sig,


### PR DESCRIPTION
## Summary
- ensure metrics logging uses estimator's llmCalls rather than candidate notes count

## Testing
- `npm test` (fails: Missing script)
- `npm run build` (fails: The symbol "est" has already been declared)
- `node - <<'NODE' ...` (verifies logged llmCalls is taken from `est.llmCalls`)

------
https://chatgpt.com/codex/tasks/task_b_68a67971a6108328b0b3d40654c38e68