### PR TITLE
feat: add retrieval depth controller with tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "tsx --test src/**/*.test.ts"
   },
   "dependencies": {
     "@google/genai": "^1.14.0",
@@ -16,6 +17,7 @@
   "devDependencies": {
     "@types/node": "^22.14.0",
     "typescript": "~5.8.2",
-    "vite": "^6.2.0"
+    "vite": "^6.2.0",
+    "tsx": "^4.19.0"
   }
 }

--- a/src/insight/depthController.test.ts
+++ b/src/insight/depthController.test.ts
@@ -1,0 +1,18 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { shouldDeepen } from './depthController';
+import { policyFor } from './budget';
+import type { Signals } from './signals';
+
+test('does not exceed max depth', () => {
+  const budget = policyFor('pro');
+  const signals: Signals = { seedCoverage: 0.5, novelty: 0.5, rerankMargin: 0.5, entropy: 0.5 };
+  assert.equal(shouldDeepen(budget.maxCycles, signals, budget), false);
+});
+
+test('early exit when benefit low', () => {
+  const budget = policyFor('pro');
+  const signals: Signals = { seedCoverage: 0, novelty: 0, rerankMargin: 0, entropy: 1 };
+  assert.equal(shouldDeepen(1, signals, budget), false);
+});
+

--- a/src/insight/depthController.ts
+++ b/src/insight/depthController.ts
@@ -1,1 +1,28 @@
-// This file is a placeholder for the depth controller logic.
+import type { Budget } from './budget';
+import type { Signals } from './signals';
+import { shouldEscalate } from './signals';
+
+/**
+ * Decide whether another retrieval cycle should be executed.
+ *
+ * @param currentDepth - 1-indexed depth of the current retrieval loop
+ * @param signals - heuristic signals derived from the current results
+ * @param budget - budget configuration for the current tier
+ * @returns true if probing should continue, false to stop
+ */
+export function shouldDeepen(
+  currentDepth: number,
+  signals: Signals,
+  budget: Budget
+): boolean {
+  // Stop if we've exhausted the allowed depth.
+  if (currentDepth >= budget.maxCycles) return false;
+
+  // Estimate cost of going deeper: assume one more LLM call and payload
+  // proportional to accumulated context.
+  const estTokens = budget.contextCapChars * currentDepth;
+  const estCalls = currentDepth;
+
+  return shouldEscalate(signals, estTokens, estCalls);
+}
+

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -7,7 +7,8 @@ import { type Tier, policyFor } from '../insight/budget';
 import { pickEvidenceSubmodular, type Frag } from '../insight/evidencePicker';
 import { capFragmentsByBudget, estTokens } from '../insight/tokenGovernor';
 import { counterInsightCheck } from '../insight/counterInsight';
-import { computeSignals, shouldEscalate } from '../insight/signals';
+import { computeSignals } from '../insight/signals';
+import { shouldDeepen } from '../insight/depthController';
 import { logMetrics } from '../insight/logging';
 
 
@@ -530,7 +531,7 @@ export const findSynapticLink = async (
                 latencyMs: Date.now() - startTime
             });
 
-            if (!shouldEscalate(sig, est.tokens, est.llmCalls)) {
+            if (!shouldDeepen(cycle, sig, budget)) {
                 break;
             }
         }


### PR DESCRIPTION
## Summary
- add `shouldDeepen` helper that halts probing when depth or budget is exhausted
- use `shouldDeepen` in `findSynapticLink` to decide on further probing
- cover max depth and early exit behaviours with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a679711d008328a828a22a0fefcbc1