### PR TITLE
fix: remove duplicate est declaration

### DIFF
--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -513,16 +513,11 @@ export const findSynapticLink = async (
                 llmCalls: 1
             };
 
-            const est = {
-                tokens: evTexts.reduce((a, b) => a + estTokens(b), 0),
-                llmCalls: 1
-            };
-
             logMetrics({
                 tier,
                 depthCycles: cycle,
                 tokensEstimated: est.tokens,
-                llmCalls: candNotes.length,
+                llmCalls: est.llmCalls,
                 candidateNotes: candNotes.length,
                 evidenceSnippets: topResult?.evidenceRefs.length ?? 0,
                 signals: sig,


### PR DESCRIPTION
## Summary
- remove duplicated `est` definition in `ai.ts`
- reuse single `est` for metrics logging and escalation checks

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a6796f2c088328a436e132425893f4