### PR TITLE
feat: add SerpAPI web search adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,10 @@ Synapse uses a combination of techniques to find connections between your notes:
     npm install
     ```
 3.  **Set up your environment variables:**
-    Create a file named `.env.local` in the root of the project and add your Gemini API key. This file is not checked into version control, so your API key will remain private.
+    Create a file named `.env.local` in the root of the project and add your Gemini API key and [SerpAPI](https://serpapi.com/) key for web search. This file is not checked into version control, so your keys will remain private.
     ```
     GEMINI_API_KEY=your_api_key
+    SERPAPI_API_KEY=your_serpapi_key
     ```
 4.  **Run the app:**
     ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,11 +13,14 @@
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-i18next": "^15.7.0",
+        "serpapi": "^2.2.1",
         "zustand": "^5.0.8"
       },
       "devDependencies": {
         "@types/node": "^22.14.0",
-
+        "@types/react": "^19.1.10",
+        "@types/react-dom": "^19.1.7",
+        "tsx": "^4.19.0",
         "typescript": "~5.8.2",
         "vite": "^6.2.0"
       }
@@ -791,6 +794,26 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/react": {
+      "version": "19.1.10",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.10.tgz",
+      "integrity": "sha512-EhBeSYX0Y6ye8pNebpKrwFJq7BoQ8J5SO6NlvNwwHjSj6adXJViPQrKlsyPw7hLBLvckEMO1yxeGdR82YBBlDg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.1.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.7.tgz",
+      "integrity": "sha512-i5ZzwYpqjmrKenzkoLM2Ibzt6mAsM7pxB6BCIouEVVmgiqaMj1TjaK7hnA36hbW5aZv20kx7Lw6hWzPWg0Rurw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.0.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -835,7 +858,13 @@
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
     },
-
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -973,7 +1002,19 @@
         "node": ">=14"
       }
     },
-
+    "node_modules/get-tsconfig": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
+      "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/google-auth-library": {
       "version": "9.15.1",
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
@@ -1013,7 +1054,15 @@
         "node": ">=14.0.0"
       }
     },
-
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
@@ -1058,7 +1107,6 @@
         }
       }
     },
-
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -1240,7 +1288,16 @@
         "typescript": {
           "optional": true
         }
-
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
     "node_modules/rollup": {
@@ -1309,6 +1366,12 @@
       "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
       "license": "MIT"
     },
+    "node_modules/serpapi": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serpapi/-/serpapi-2.2.1.tgz",
+      "integrity": "sha512-1HXXaIwDmYueFPauAggIkzozMi5P/a4/yRUxB8Z1kad0VQE/7ohf9a6xRQ99aXR252itDChfmJUfBdCA4phCYA==",
+      "license": "MIT"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1342,13 +1405,31 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
     },
-
+    "node_modules/tsx": {
+      "version": "4.20.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.4.tgz",
+      "integrity": "sha512-yyxBKfORQ7LuRt/BQKBXrpcq59ZvSW0XxwfjAt3w2/8PmdxaFzijtMhTawprSHhpzeM5BgU2hXHG3lklIERZXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "devOptional": true,
-
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -1462,7 +1543,6 @@
         "node": ">=0.10.0"
       }
     },
-
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -1528,7 +1608,6 @@
           "optional": true
         }
       }
-
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-i18next": "^15.7.0",
+    "serpapi": "^2.2.1",
     "zustand": "^5.0.8"
   },
   "devDependencies": {

--- a/src/agentic/adapters/searchWeb.ts
+++ b/src/agentic/adapters/searchWeb.ts
@@ -1,0 +1,36 @@
+import { getJson } from 'serpapi';
+
+export interface WebSearchResult {
+    title: string;
+    url: string;
+    snippet: string;
+}
+
+/**
+ * Perform a web search using the SerpAPI provider.
+ * @param query The search query string.
+ * @returns Array of mapped search results.
+ */
+export async function search(query: string): Promise<WebSearchResult[]> {
+    const apiKey = process.env.SERPAPI_API_KEY;
+    if (!apiKey) {
+        throw new Error('SERPAPI_API_KEY environment variable not set');
+    }
+
+    try {
+        const data = await getJson({
+            engine: 'google',
+            q: query,
+            api_key: apiKey
+        });
+        const results: any[] = data.organic_results || [];
+        return results.map((r: any) => ({
+            title: r.title ?? '',
+            url: r.link ?? '',
+            snippet: r.snippet ?? ''
+        }));
+    } catch (error: any) {
+        console.error('SerpAPI search failed:', error);
+        throw new Error(`SerpAPI search failed: ${error.message || error}`);
+    }
+}


### PR DESCRIPTION
## Summary
- integrate SerpAPI web search adapter that maps search titles, snippets, and URLs
- document SERPAPI_API_KEY setup in README
- add serpapi dependency

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a6e2efe77883289ff63af4ad016348