### PR TITLE
refactor: centralize tier type

### DIFF
--- a/src/agentic/budget.ts
+++ b/src/agentic/budget.ts
@@ -1,0 +1,7 @@
+import type { Tier, Budget } from '../insight/budget';
+import { policyFor as insightPolicyFor, TIERS } from '../insight/budget';
+
+export { TIERS };
+export type { Budget };
+
+export const policyFor = (tier: Tier): Budget => insightPolicyFor(tier);


### PR DESCRIPTION
## Summary
- add agentic budget module that reuses Tier, Budget and policy from insight budget

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a6e2f0bed083288286e424b21ab7ed