### PR TITLE
feat: support multi-hop retrieval

### DIFF
--- a/src/insight/budget.ts
+++ b/src/insight/budget.ts
@@ -8,12 +8,13 @@ export type Budget = {
   maxCycles: number;      // Como-style loop count
   tempProbe: number;      // temperature for self-probe
   tempInsight: number;    // temperature for insight prompt
+  maxHopDepth: number;    // chain length for multi-hop retrieval
   contextCapChars: number; // hard cap for evidence text payload
 };
 
 export const TIERS: Record<Tier, Budget> = {
-  free: { maxQueries: 4,  perQueryK: 5,  finalK: 4,  maxFragments: 12, maxCycles: 1, tempProbe: 0.2, tempInsight: 0.2, contextCapChars: 3500 },
-  pro:  { maxQueries: 10, perQueryK: 12, finalK: 8,  maxFragments: 24, maxCycles: 3, tempProbe: 0.7, tempInsight: 0.5, contextCapChars: 4500 }
+  free: { maxQueries: 4,  perQueryK: 5,  finalK: 4,  maxFragments: 12, maxCycles: 1, tempProbe: 0.2, tempInsight: 0.2, maxHopDepth: 1, contextCapChars: 3500 },
+  pro:  { maxQueries: 10, perQueryK: 12, finalK: 8,  maxFragments: 24, maxCycles: 3, tempProbe: 0.7, tempInsight: 0.5, maxHopDepth: 2, contextCapChars: 4500 }
 };
 
 export const policyFor = (tier: Tier) => TIERS[tier];

--- a/src/insight/evidencePicker.ts
+++ b/src/insight/evidencePicker.ts
@@ -14,9 +14,11 @@ export function pickEvidenceSubmodular(
   pool: Frag[],                         // candidate fragments
   queryText: string,
   maxFragments: number,
-  perNoteCap = Math.max(4, Math.ceil(maxFragments/3)),
+  perNoteCap?: number,
   redundancyJaccard = 0.8
 ): Frag[] {
+  const noteCount = new Set(pool.map(p => p.noteId)).size || 1;
+  const cap = perNoteCap ?? Math.max(2, Math.ceil(maxFragments / noteCount));
   const qF = FEATURES(queryText);
   const candidates = pool.map(f => ({ f, F: FEATURES(f.text) }));
 
@@ -31,7 +33,7 @@ export function pickEvidenceSubmodular(
       const { f, F } = candidates[i];
       // enforce per-note cap
       const used = usedByNote.get(f.noteId) ?? 0;
-      if (used >= perNoteCap) continue;
+      if (used >= cap) continue;
       // redundancy filter
       if (chosen.some(x => OVERLAP(x.F, F) > redundancyJaccard)) continue;
 


### PR DESCRIPTION
## Summary
- allow budgets to limit multi-hop chain depth
- expand evidence picker with per-note caps for grouped notes
- enable multi-hop chain retrieval and group synthesis in AI pipeline

## Testing
- `npm test`
- `npx tsc --noEmit` *(fails: "Object literal may only specify known properties, and 'budget' does not exist in type" etc.)*

------
https://chatgpt.com/codex/tasks/task_b_68a7d7ff184883288997b8ef0cbcc770