### PR TITLE
feat: add random candidate injection

### DIFF
--- a/src/insight/budget.ts
+++ b/src/insight/budget.ts
@@ -4,6 +4,7 @@ export type Budget = {
   maxQueries: number;     // query expansion + self-probe cap
   perQueryK: number;      // vector hits per query
   finalK: number;         // fused candidate notes
+  randomInject: number;   // random notes to inject for serendipity
   maxFragments: number;   // evidence snippets per pair
   maxCycles: number;      // Como-style loop count
   tempProbe: number;      // temperature for self-probe
@@ -12,8 +13,8 @@ export type Budget = {
 };
 
 export const TIERS: Record<Tier, Budget> = {
-  free: { maxQueries: 4,  perQueryK: 5,  finalK: 4,  maxFragments: 12, maxCycles: 1, tempProbe: 0.2, tempInsight: 0.2, contextCapChars: 3500 },
-  pro:  { maxQueries: 10, perQueryK: 12, finalK: 8,  maxFragments: 24, maxCycles: 3, tempProbe: 0.7, tempInsight: 0.5, contextCapChars: 4500 }
+  free: { maxQueries: 4,  perQueryK: 5,  finalK: 4,  randomInject: 1, maxFragments: 12, maxCycles: 1, tempProbe: 0.2, tempInsight: 0.2, contextCapChars: 3500 },
+  pro:  { maxQueries: 10, perQueryK: 12, finalK: 8,  randomInject: 2, maxFragments: 24, maxCycles: 3, tempProbe: 0.7, tempInsight: 0.5, contextCapChars: 4500 }
 };
 
 export const policyFor = (tier: Tier) => TIERS[tier];


### PR DESCRIPTION
## Summary
- add `randomInject` to budget tiers
- allow candidate retrieval to inject random notes
- pass budget's `randomInject` through findSynapticLink

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a7d81274248328b86d99dd44a42a5d