### PR TITLE
refactor: Remove Chinese output instruction

### DIFF
--- a/src/insight/questionGenerator.ts
+++ b/src/insight/questionGenerator.ts
@@ -1,9 +1,6 @@
 import { GoogleGenAI } from '@google/genai';
 import type { Language } from '../context/LanguageProvider';
 
-// This should only be used for free-text generation, not for JSON mode.
-const CHINESE_OUTPUT_INSTRUCTION = "\n\nCRITICAL: You MUST respond exclusively in Simplified Chinese.";
-
 // --- Divergent Question Generation ---
 
 /**
@@ -28,7 +25,7 @@ CURRENT DRAFT:
 """
 ${draft.slice(0, 15000)}
 """
-${language === 'zh' ? CHINESE_OUTPUT_INSTRUCTION : ''}
+
 Return ONLY the single question as a raw string, not in a JSON object.`;
 
     try {

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -37,9 +37,6 @@ if (process.env.API_KEY) {
 
 export const ai = aiInstance;
 
-// This should only be used for free-text generation, not for JSON mode.
-export const CHINESE_OUTPUT_INSTRUCTION = "\n\nCRITICAL: You MUST respond exclusively in Simplified Chinese.";
-
 export const safeParseGeminiJson = <T,>(text: string): T | null => {
     const jsonText = text.trim();
     if (!jsonText || jsonText.toLowerCase() === 'null') return null;
@@ -239,7 +236,7 @@ Your task:
 4.  Keep the draft concise (2-4 sentences).
 
 This is a preliminary draft that will be iteratively improved with more information.
-${language === 'zh' ? CHINESE_OUTPUT_INSTRUCTION : ''}
+
 Return ONLY the text of the draft.`;
 
     try {
@@ -515,7 +512,7 @@ Instructions:
 4.  If the new information provides a source, you can add a citation like [Source: Note Title].
 5.  Maintain the draft's original structure and coherence. The goal is to refine and expand, not to rewrite completely.
 6.  If the new information is not relevant, return the original draft unchanged.
-${language === 'zh' ? CHINESE_OUTPUT_INSTRUCTION : ''}
+
 Return ONLY the updated draft text.`;
 
     try {


### PR DESCRIPTION
Removes the hardcoded instruction for the language model to respond in Chinese when the language is set to 'zh'.

The `CHINESE_OUTPUT_INSTRUCTION` constant was removed from:
- src/lib/ai.ts
- src/insight/questionGenerator.ts

Its usage was also removed from the `generateInitialDraft`, `integrateEvidenceIntoDraft`, and `generateDivergentQuestion` functions.

This change allows for English-only output from the language model, which can then be translated as a separate step.