### PR TITLE
feat: stream gemini responses

### DIFF
--- a/src/agentic/mindMap.ts
+++ b/src/agentic/mindMap.ts
@@ -22,10 +22,14 @@ export async function buildMindMapFromTranscript(transcript: string): Promise<Mi
 Return JSON with nodes (entity|concept|claim), edges (s,t,rel), and 1–3 short summaries.
 Be faithful; no hallucinations.`;
 
-  const res = await ai.models.generateContent({
+  const stream = await ai.models.generateContentStream({
     model: MODEL_NAME,
     contents: `${prompt}\n---\n${transcript.slice(0, 6000)}\n---`,
     config: { responseMimeType:'application/json', responseSchema: MAP_SCHEMA, temperature: 0.2 }
   });
-  return safeParseGeminiJson<MindMap>(res.text);
+  let jsonText = '';
+  for await (const chunk of stream) {
+    jsonText += chunk.text ?? '';
+  }
+  return safeParseGeminiJson<MindMap>(jsonText);
 }

--- a/src/agentic/planner.ts
+++ b/src/agentic/planner.ts
@@ -44,12 +44,16 @@ MIND_HINTS:
 TRANSCRIPT:
 ${transcript.slice(0, 3000)}`;
 
-  const res = await ai.models.generateContent({
+  const stream = await ai.models.generateContentStream({
     model: MODEL_NAME,
     contents: [{ role: 'user', parts: [{ text: contents }] }],
     // @ts-ignore
     config: { responseMimeType:'application/json', responseSchema: PLAN_SCHEMA, temperature }
   });
-  const plan = safeParseGeminiJson<PlanJSON>(res.candidates?.[0]?.content?.parts?.[0]?.text ?? '');
+  let jsonText = '';
+  for await (const chunk of stream) {
+    jsonText += chunk.text ?? '';
+  }
+  const plan = safeParseGeminiJson<PlanJSON>(jsonText);
   return plan;
 }


### PR DESCRIPTION
## Summary
- switch agentic loop to Gemini `generateContentStream` and log partial chunks
- stream model output in planner, mind map builder, and self-evolution logic
- adjust evolution tests for streamed responses

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68aaadc5cec48328bf54db2b801291ba