### PR TITLE
feat: add thinking indicator with modal

### DIFF
--- a/index.css
+++ b/index.css
@@ -803,6 +803,16 @@ textarea {
     margin: 0;
 }
 
+.thinking-status-header .close-button {
+    margin-left: auto;
+    background: none;
+    border: none;
+    color: var(--primary-text-color);
+    cursor: pointer;
+    font-size: 1.25rem;
+    line-height: 1;
+}
+
 .thinking-status-log {
     list-style-type: none;
     padding-left: 0;
@@ -833,6 +843,21 @@ textarea {
 .thinking-status-log .icon .spinner {
     width: 16px;
     height: 16px;
+}
+
+.thinking-indicator {
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+    background-color: rgba(30, 30, 30, 0.8);
+    border: 1px solid var(--border-color);
+    border-radius: 9999px;
+    padding: 0.5rem 1rem;
+    color: var(--primary-text-color);
+    cursor: pointer;
+    z-index: 1500;
+    box-shadow: 0 4px 10px rgba(0,0,0,0.3);
+    font-size: 0.9rem;
 }
 
 .note-editor-actions {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -4,7 +4,7 @@ import { useLogStore } from '../lib/logStore';
 
 import { NoteEditor } from './NoteEditor';
 import { NoteViewer } from './NoteViewer';
-import { ThinkingStatus } from './ThinkingStatus';
+import { ThinkingIndicator } from './ThinkingIndicator';
 import { useTranslation } from '../context/LanguageProvider';
 import { Vault } from './Vault';
 import { Inbox } from './Inbox';
@@ -18,7 +18,6 @@ export const App: React.FC = () => {
         setIsEditing,
         viewingNote,
         setViewingNote,
-        loadingState,
         newInsightCount,
         handleSaveNote,
         handleBulkUpload,
@@ -88,7 +87,7 @@ export const App: React.FC = () => {
 
             {isEditing && <NoteEditor onClose={() => setIsEditing(false)} />}
             {viewingNote && <NoteViewer note={viewingNote} onClose={() => setViewingNote(null)} />}
-            {loadingState.active && <ThinkingStatus messages={loadingState.messages} />}
+            <ThinkingIndicator />
 
             {!ai && <div style={{position: 'fixed', bottom: 0, left:0, right: 0, background: 'var(--danger-color)', padding: '1rem', textAlign: 'center', color: 'white', zIndex: 2000}}>
                 {t('apiKeyWarning')}

--- a/src/components/ThinkingIndicator.tsx
+++ b/src/components/ThinkingIndicator.tsx
@@ -1,0 +1,29 @@
+import React, { useState, useEffect } from 'react';
+import { useLogStore } from '../lib/logStore';
+import { ThinkingStatus } from './ThinkingStatus';
+import { useTranslation } from '../context/LanguageProvider';
+
+export const ThinkingIndicator: React.FC = () => {
+    const thinkingSteps = useLogStore(state => state.thinkingSteps);
+    const [open, setOpen] = useState(false);
+    const { t } = useTranslation();
+
+    useEffect(() => {
+        if (thinkingSteps.length === 0 && open) {
+            setOpen(false);
+        }
+    }, [thinkingSteps, open]);
+
+    if (thinkingSteps.length === 0) return null;
+
+    return (
+        <>
+            {!open && (
+                <div className="thinking-indicator" onClick={() => setOpen(true)}>
+                    🧠 {t('thinkingInProgress')}
+                </div>
+            )}
+            {open && <ThinkingStatus messages={thinkingSteps} onClose={() => setOpen(false)} />}
+        </>
+    );
+};

--- a/src/components/ThinkingStatus.tsx
+++ b/src/components/ThinkingStatus.tsx
@@ -1,7 +1,9 @@
 import React, { useEffect, useRef } from 'react';
+import { useTranslation } from '../context/LanguageProvider';
 
-export const ThinkingStatus: React.FC<{ messages: string[] }> = ({ messages }) => {
+export const ThinkingStatus: React.FC<{ messages: string[]; onClose?: () => void }> = ({ messages, onClose }) => {
     const messagesEndRef = useRef<HTMLDivElement>(null);
+    const { t } = useTranslation();
 
     const scrollToBottom = () => {
         messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
@@ -17,7 +19,12 @@ export const ThinkingStatus: React.FC<{ messages: string[] }> = ({ messages }) =
         <div className="thinking-status-overlay">
             <div className="thinking-status-content">
                 <div className="thinking-status-header">
-                    <h3>🧠 Synapse is Thinking...</h3>
+                    <h3>🧠 {t('synapseThinking')}</h3>
+                    {onClose && (
+                        <button className="close-button" onClick={onClose} aria-label={t('hideThinkingProcess')}>
+                            &times;
+                        </button>
+                    )}
                 </div>
                 <ul className="thinking-status-log">
                     {completedMessages.map((msg, index) => (

--- a/src/context/translations.ts
+++ b/src/context/translations.ts
@@ -66,6 +66,8 @@ export const translations = {
     deleteConfirmation: 'Are you sure you want to delete this note and all its associated insights? This action cannot be undone.',
     apiKeyWarning: 'Warning: API_KEY is not configured. AI connection features are disabled.',
     languageToggle: '中文',
+    thinkingInProgress: 'Thinking...',
+    synapseThinking: 'Synapse is Thinking...',
     // Thinking Status
     thinkingBrainstorming: 'Brainstorming avenues of inquiry...',
     thinkingSearching: 'Searching knowledge base for relevant concepts...',
@@ -145,6 +147,8 @@ export const translations = {
     deleteConfirmation: '您确定要删除此笔记及其所有相关见解吗？此操作无法撤销。',
     apiKeyWarning: '警告：未配置 API_KEY。AI 连接功能已禁用。',
     languageToggle: 'EN',
+    thinkingInProgress: '正在思考中...',
+    synapseThinking: 'Synapse 正在思考...',
      // Thinking Status
     thinkingBrainstorming: '正在构思探究途径...',
     thinkingSearching: '正在知识库中搜索相关概念...',

--- a/src/lib/logStore.ts
+++ b/src/lib/logStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import i18n from '../context/i18n';
 
 export type DevLog = {
   timestamp: string;
@@ -31,7 +32,7 @@ export const useLogStore = create<LogStoreState>((set, get) => ({
     // Clear logs from the previous run
     set({ thinkingSteps: [], devLogs: [] });
     // Add an initial "Thinking..." message for the user
-    get().addThinkingStep('正在思考中...');
+    get().addThinkingStep(i18n.t('thinkingInProgress'));
     get().addDevLog({
         source: 'system',
         type: 'info',
@@ -42,7 +43,7 @@ export const useLogStore = create<LogStoreState>((set, get) => ({
   addThinkingStep: (step: string) => {
     set(state => {
         // Replace "Thinking..." with the first real step, otherwise append.
-        const newSteps = state.thinkingSteps[0] === '正在思考中...'
+        const newSteps = state.thinkingSteps[0] === i18n.t('thinkingInProgress')
             ? [step]
             : [...state.thinkingSteps, step];
         return { thinkingSteps: newSteps };


### PR DESCRIPTION
## Summary
- add compact ThinkingIndicator pill that opens detailed ThinkingStatus modal
- localize thinking labels and modal title via translations
- wire indicator into App and route thinking steps through log store

## Testing
- `npm test` *(fails: The requested module './ai' does not provide an export named 'CHINESE_OUTPUT_INSTRUCTION')*

------
https://chatgpt.com/codex/tasks/task_b_68aaada624548328860e4bfaf9b7a698