### PR TITLE
feat: clamp agent transcripts by token count

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "synapse-v0.14",
       "version": "0.0.0",
       "dependencies": {
+        "@dqbd/tiktoken": "^1.0.15",
         "@google/genai": "^1.14.0",
         "better-sqlite3": "^11.1.2",
         "i18next": "^25.4.0",
@@ -38,6 +39,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@dqbd/tiktoken": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/@dqbd/tiktoken/-/tiktoken-1.0.22.tgz",
+      "integrity": "sha512-RYhO8xeHkMNX5Ixqf4M1Ve3siCYJY/dI0yLnlX4M4oIEDOvjMIQ+E+3OUpAaZcWTaMtQJzGcDAghYfllpx3i/w==",
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.9",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "react-dom": "^19.1.1",
     "react-i18next": "^15.7.0",
     "zod": "^3.23.8",
-    "zustand": "^5.0.8"
+    "zustand": "^5.0.8",
+    "@dqbd/tiktoken": "^1.0.15"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.11",

--- a/src/agentic/agenticLoop.ts
+++ b/src/agentic/agenticLoop.ts
@@ -1,5 +1,6 @@
 import type { ToolResult } from './types';
 import { planNextStep } from './planner';
+import { clampTranscript } from './contextPolicy';
 import { AGENT_BUDGET, type Tier } from './budget';
 import type { Tool } from './tools/tool';
 import type { MindMapTool } from './tools/mindMapTool';
@@ -46,6 +47,7 @@ export async function runAgenticInsight(
   const mindMapTool = tools.find(t => t.name === 'mind_map') as MindMapTool | undefined;
 
   while (steps < budget.maxSteps && toolCalls < budget.maxToolCalls) {
+    ctx.transcript = clampTranscript(ctx.transcript, budget.contextCapChars);
     const transcriptText = ctx.transcript.join('\n');
     if (mindMapTool) {
       await mindMapTool.update(transcriptText);

--- a/src/agentic/contextPolicy.ts
+++ b/src/agentic/contextPolicy.ts
@@ -1,0 +1,14 @@
+import { countTokens } from './tokenizer';
+
+export function clampTranscript(transcript: string[], maxTokens: number): string[] {
+  const result: string[] = [];
+  let total = 0;
+  for (let i = transcript.length - 1; i >= 0; i--) {
+    const entry = transcript[i];
+    const tokens = countTokens(entry);
+    if (total + tokens > maxTokens) break;
+    total += tokens;
+    result.unshift(entry);
+  }
+  return result;
+}

--- a/src/agentic/tokenizer.ts
+++ b/src/agentic/tokenizer.ts
@@ -1,0 +1,14 @@
+import { get_encoding, Tiktoken } from '@dqbd/tiktoken';
+
+let encoder: Tiktoken | null = null;
+
+function getEncoder(): Tiktoken {
+  if (!encoder) {
+    encoder = get_encoding('cl100k_base');
+  }
+  return encoder;
+}
+
+export function countTokens(text: string): number {
+  return getEncoder().encode(text).length;
+}


### PR DESCRIPTION
## Summary
- add tokenizer utility using @dqbd/tiktoken
- clamp agent transcripts to a token budget
- wire the clamp into runAgenticInsight for token-aware context

## Testing
- `npm test`
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module '../insight/tokenGovernor' or its corresponding type declarations, etc.)*


------
https://chatgpt.com/codex/tasks/task_b_68b4e73ea3648328999984fa77d434d8