### PR TITLE
Ensure pytest resolves project modules

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,7 @@
 [pytest]
+pythonpath =
+    .
+    src
 asyncio_mode = auto
 filterwarnings =
     ignore:builtin type SwigPy.* has no __module__:DeprecationWarning


### PR DESCRIPTION
## Summary
- add project root and `src` to pytest Python path so test imports resolve
- mock heavy dependencies in insight flow test to keep job completion within polling interval

## Testing
- `pytest tests/test_api.py::test_insight_generation_flow -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b4e7353da88328b3ec8b91f871aa94