### PR TITLE
Ensure pytest resolves project modules

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,8 @@
 [pytest]
+pythonpath =
+    .
+    src
 asyncio_mode = auto
 filterwarnings =
-    ignore:builtin type SwigPy.* has no __module__:DeprecationWarning
-    ignore:swigvarlink has no __module__:DeprecationWarning
+    ignore:builtin type SwigPy.* has no __module__ attribute:DeprecationWarning
+    ignore:builtin type swigvarlink has no __module__ attribute:DeprecationWarning

--- a/server.py
+++ b/server.py
@@ -63,7 +63,10 @@ async def generate_insights(req: GenerateInsightsRequest, tasks: BackgroundTasks
                 try:
                     all_notes_db = await crud.get_notes(db, limit=1000) # A reasonable limit for now
                     # Convert SQLAlchemy models to dicts for the pipeline
-                    all_notes = [schemas.Note.from_orm(n).model_dump(mode='json') for n in all_notes_db]
+                    all_notes = [
+                        schemas.Note.model_validate(n).model_dump(mode="json")
+                        for n in all_notes_db
+                    ]
 
                     if not all_notes:
                         raise ValueError("No notes found in the database.")


### PR DESCRIPTION
## Summary
- add project root and `src` to pytest Python path so test imports resolve
- mock heavy dependencies in insight flow test to keep job completion within polling interval
- replace deprecated Pydantic `from_orm` usage and filter swigvarlink warning

## Testing
- `pytest tests/test_api.py::test_insight_generation_flow -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b4e7353da88328b3ec8b91f871aa94