### PR TITLE
refactor: handle deprecations and clustering stability

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,4 +2,4 @@
 asyncio_mode = auto
 filterwarnings =
     ignore:builtin type SwigPy.* has no __module__:DeprecationWarning
-    ignore:swigvarlink has no __module__:DeprecationWarning
+    ignore:builtin type swigvarlink has no __module__ attribute:DeprecationWarning

--- a/server.py
+++ b/server.py
@@ -63,7 +63,10 @@ async def generate_insights(req: GenerateInsightsRequest, tasks: BackgroundTasks
                 try:
                     all_notes_db = await crud.get_notes(db, limit=1000) # A reasonable limit for now
                     # Convert SQLAlchemy models to dicts for the pipeline
-                    all_notes = [schemas.Note.from_orm(n).model_dump(mode='json') for n in all_notes_db]
+                    all_notes = [
+                        schemas.Note.model_validate(n).model_dump(mode="json")
+                        for n in all_notes_db
+                    ]
 
                     if not all_notes:
                         raise ValueError("No notes found in the database.")

--- a/src/eureka_rag/clusterer.py
+++ b/src/eureka_rag/clusterer.py
@@ -31,6 +31,10 @@ class Clusterer:
         else:
             n_clusters = self.n_clusters
 
+        # Ensure we don't request more clusters than distinct points
+        unique_points = np.unique(embeddings, axis=0)
+        n_clusters = min(n_clusters, len(unique_points))
+
         if n_clusters <= 0:
             return {}
 


### PR DESCRIPTION
## Summary
- replace deprecated `from_orm` calls with `model_validate`
- cap KMeans clusters by number of unique embeddings to avoid convergence warnings
- silence `swigvarlink` DeprecationWarning during tests

## Testing
- `PYTHONPATH=. pytest tests/test_planner.py -q`
- `PYTHONPATH=. pytest tests/test_api.py::test_insight_generation_flow -q` *(fails: SSL_ERROR_SSL: self signed certificate)*

------
https://chatgpt.com/codex/tasks/task_b_68b50017563c8328a394ddab8faff84a