### PR TITLE
feat: add long term memory to yaotong

### DIFF
--- a/src/synapse/yaotong/orchestrator/yaotong.py
+++ b/src/synapse/yaotong/orchestrator/yaotong.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
-from typing import Dict, Any
+from typing import Dict, Any, List
+from pathlib import Path
+import json
 from synapse.yaotong.models.recipe import Recipe, ProviderCfg
 from synapse.yaotong.tooling.base import LocalTool, MCPTool, ToolHandle
 from synapse.yaotong.mcp.client_manager import MCPClientManager
@@ -10,10 +12,37 @@ class WorkingMemory(dict):
     def snapshot(self) -> Dict[str, Any]:
         return dict(self)
 
+class LongTermMemory:
+    def __init__(self, path: str | Path = "yaotong_memory.json") -> None:
+        self.path = Path(path)
+        if self.path.exists():
+            with self.path.open("r", encoding="utf-8") as f:
+                self.data = json.load(f)
+        else:
+            self.data = {}
+
+    def save_pill(self, goal: str, pills: List[Dict[str, Any]]) -> None:
+        self.data.setdefault(goal, [])
+        self.data[goal].extend(pills)
+        with self.path.open("w", encoding="utf-8") as f:
+            json.dump(self.data, f)
+
+    def load_context(self, goal: str) -> List[Dict[str, Any]]:
+        if self.path.exists():
+            with self.path.open("r", encoding="utf-8") as f:
+                self.data = json.load(f)
+        return list(self.data.get(goal, []))
+
 class YaoTong:
-    def __init__(self, recipe: Recipe, mcp: MCPClientManager | None = None):
+    def __init__(
+        self,
+        recipe: Recipe,
+        mcp: MCPClientManager | None = None,
+        memory_store: LongTermMemory | None = None,
+    ):
         self.recipe = recipe
         self.mcp = mcp or MCPClientManager()
+        self.memory_store = memory_store or LongTermMemory()
         self.wm: WorkingMemory = WorkingMemory()
         self.tools: Dict[str, ToolHandle] = {}
 
@@ -34,7 +63,11 @@ class YaoTong:
         # add others in later sprints (facet.extract, hypothesis.generate/score, verify, graph.merge)
 
     async def run(self, goal: str) -> Dict[str, Any]:
+        self.wm = WorkingMemory()
         self.wm["goal"] = goal
+        context = self.memory_store.load_context(goal)
+        if context:
+            self.wm["context"] = context
         # phase 1: retrieval (mocked local tool by default)
         out = await self.tools["retrieve"].call({"query": goal, "top_k": 10})
         self.wm["hits"] = out.get("hits", [])
@@ -48,4 +81,5 @@ class YaoTong:
         # phase 3: fusion compose
         pills = await self.tools["fusion_compose"].call({"hypotheses": hyps})
         self.wm["pills"] = pills.get("pills", [])
-        return {"goal": goal, "pills": self.wm["pills"], "trace": {"hits": self.wm["hits"]}}
+        self.memory_store.save_pill(goal, self.wm["pills"])
+        return {"goal": goal, "pills": self.wm["pills"], "context": self.wm.get("context", []), "trace": {"hits": self.wm["hits"]}}

--- a/tests/test_long_term_memory.py
+++ b/tests/test_long_term_memory.py
@@ -1,0 +1,20 @@
+import pytest
+from synapse.yaotong.models.recipe import Recipe
+from synapse.yaotong.orchestrator.yaotong import YaoTong, LongTermMemory
+
+
+@pytest.mark.asyncio
+async def test_long_term_memory_persists(tmp_path):
+    recipe = Recipe(recipe_id="rcp_memory")
+    mem_path = tmp_path / "memory.json"
+    memory = LongTermMemory(mem_path)
+    yt = YaoTong(recipe, memory_store=memory)
+    await yt.setup()
+    first = await yt.run("quantum computing")
+    assert first["pills"]
+
+    # new orchestrator instance simulating a new request
+    yt2 = YaoTong(recipe, memory_store=LongTermMemory(mem_path))
+    await yt2.setup()
+    second = await yt2.run("quantum computing")
+    assert second["context"] == first["pills"]


### PR DESCRIPTION
## Summary
- add simple file-based LongTermMemory with save and load methods
- let YaoTong orchestrator accept a memory store and persist pills
- test that pills from previous run are loaded into context

## Testing
- `venv/bin/python -m pytest tests/test_long_term_memory.py`
- `venv/bin/python -m pytest tests/test_tool_resolution.py`


------
https://chatgpt.com/codex/tasks/task_b_68b54b5646ac8328b373bbae7085a48c