### PR TITLE
feat: add initial graph builder tool

### DIFF
--- a/src/synapse/yaotong/orchestrator/yaotong.py
+++ b/src/synapse/yaotong/orchestrator/yaotong.py
@@ -5,6 +5,7 @@ from synapse.yaotong.tooling.base import LocalTool, MCPTool, ToolHandle
 from synapse.yaotong.mcp.client_manager import MCPClientManager
 from synapse.yaotong.tools.local_retrieval import retrieve_tool
 from synapse.yaotong.tools.local_fusion import fusion_compose_tool
+from synapse.yaotong.tools.graph_builder import graph_builder_tool
 
 class WorkingMemory(dict):
     def snapshot(self) -> Dict[str, Any]:
@@ -31,13 +32,17 @@ class YaoTong:
     async def setup(self) -> None:
         await self._resolve_tool("retrieve", retrieve_tool)
         await self._resolve_tool("fusion_compose", fusion_compose_tool)
+        await self._resolve_tool("graph_build", graph_builder_tool)
         # add others in later sprints (facet.extract, hypothesis.generate/score, verify, graph.merge)
 
-    async def run(self, goal: str) -> Dict[str, Any]:
+    async def run(self, goal: str, use_graph: bool = False) -> Dict[str, Any]:
         self.wm["goal"] = goal
         # phase 1: retrieval (mocked local tool by default)
         out = await self.tools["retrieve"].call({"query": goal, "top_k": 10})
         self.wm["hits"] = out.get("hits", [])
+        if use_graph:
+            graph = await self.tools["graph_build"].call({"notes": []})
+            self.wm["graph"] = graph
         # phase 2: (placeholder) hypotheses
         hyps = [{
             "id": "h1",
@@ -48,4 +53,7 @@ class YaoTong:
         # phase 3: fusion compose
         pills = await self.tools["fusion_compose"].call({"hypotheses": hyps})
         self.wm["pills"] = pills.get("pills", [])
-        return {"goal": goal, "pills": self.wm["pills"], "trace": {"hits": self.wm["hits"]}}
+        trace = {"hits": self.wm["hits"]}
+        if use_graph:
+            trace["graph"] = self.wm["graph"]
+        return {"goal": goal, "pills": self.wm["pills"], "trace": trace}

--- a/src/synapse/yaotong/tools/graph_builder.py
+++ b/src/synapse/yaotong/tools/graph_builder.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+from typing import List, Dict
+from database.schemas import Note
+
+async def build_graph(notes: List[Note]) -> Dict:
+    """Build a simple graph placeholder from notes."""
+    nodes = [{"id": str(n.id), "title": n.title} for n in notes]
+    edges: List[Dict[str, str]] = []
+    return {"nodes": nodes, "edges": edges}
+
+# Expose as tool entry point
+graph_builder_tool = build_graph

--- a/tests/test_graph_builder.py
+++ b/tests/test_graph_builder.py
@@ -1,0 +1,20 @@
+import pytest
+from synapse.yaotong.models.recipe import Recipe, ProviderCfg
+from synapse.yaotong.orchestrator.yaotong import YaoTong
+
+@pytest.mark.asyncio
+async def test_graph_builder_integration():
+    recipe = Recipe(
+        recipe_id="rcp_graph",
+        providers={
+            "retrieve": ProviderCfg(type="local"),
+            "fusion_compose": ProviderCfg(type="local"),
+            "graph_build": ProviderCfg(type="local"),
+        }
+    )
+    yt = YaoTong(recipe)
+    await yt.setup()
+    result = await yt.run("Explore graphs", use_graph=True)
+    graph = result["trace"].get("graph")
+    assert isinstance(graph, dict)
+    assert "nodes" in graph and "edges" in graph


### PR DESCRIPTION
## Summary
- add placeholder graph builder tool producing node and edge lists
- register graph build tool in YaoTong orchestrator and invoke it when requested
- test graph builder integration and structure

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b54b5494b083289e1c49b56132bfa7