### PR TITLE
feat: wire up local retrieval tool and tests

### DIFF
--- a/src/synapse/yaotong/tools/local_retrieval.py
+++ b/src/synapse/yaotong/tools/local_retrieval.py
@@ -1,13 +1,39 @@
-# synapse/yaotong/tools/local_retrieval.py
-from typing import Dict, Any
+"""Local retrieval tool for YaoTong orchestrator."""
 
-# Replace the TODO with your repo's retrieval entrypoint.
-# e.g., existing hybrid retrieval (lexical + vector + RRF)
+from typing import Dict, Any, List
+
+from src.eureka_rag.retrieval import retrieve_candidate_notes
+from src.database import crud, database
+
+
 async def retrieve_tool(query: str, top_k: int = 10) -> Dict[str, Any]:
+    """Hybrid retrieval over locally stored notes.
+
+    Args:
+        query: Search query string.
+        top_k: Maximum number of notes to return.
+
+    Returns:
+        {"hits": [{"note_id": str, "score": float}, ...]}
     """
-    Returns: {"hits": [{"note_id": "...", "score": ...}, ...]}
-    """
-    # TODO: call your current retrieval function:
-    # hits = await retrieval.search(query, top_k=top_k)
-    hits = [{"note_id":"demo-1","score":0.91},{"note_id":"demo-2","score":0.87}]
-    return {"hits": hits}
+    try:
+        async with database.SessionLocal() as db:
+            notes_db = await crud.get_notes(db, limit=1000)
+            all_notes: List[Dict[str, Any]] = [
+                {"id": str(n.id), "title": n.title, "content": n.content or ""}
+                for n in notes_db
+            ]
+
+            note_ids = await retrieve_candidate_notes(
+                [query], db, all_notes, exclude_note_id="", top_k=top_k
+            )
+
+        hits = [
+            {"note_id": nid, "score": 1.0 / (idx + 1)}
+            for idx, nid in enumerate(note_ids)
+        ]
+        return {"hits": hits}
+    except Exception as e:  # pragma: no cover - defensive
+        # Ensure agent does not crash if retrieval fails
+        print(f"retrieve_tool error: {e}")
+        return {"hits": []}

--- a/tests/test_local_retrieval.py
+++ b/tests/test_local_retrieval.py
@@ -1,0 +1,34 @@
+import types
+import pytest
+
+import synapse.yaotong.tools.local_retrieval as lr
+
+
+class DummySession:
+    async def __aenter__(self):
+        return None
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_retrieve_tool_format(monkeypatch):
+    # Stub database session and note fetching
+    monkeypatch.setattr(lr.database, "SessionLocal", lambda: DummySession())
+
+    async def fake_get_notes(db, limit=1000):
+        return [types.SimpleNamespace(id="n1", title="note", content="text")]
+
+    async def fake_retrieve_candidate_notes(queries, db, all_notes, exclude_note_id, top_k):
+        return ["n1", "n2"]
+
+    monkeypatch.setattr(lr.crud, "get_notes", fake_get_notes)
+    monkeypatch.setattr(lr, "retrieve_candidate_notes", fake_retrieve_candidate_notes)
+
+    result = await lr.retrieve_tool("query", top_k=2)
+    assert "hits" in result
+    hits = result["hits"]
+    assert isinstance(hits, list) and len(hits) == 2
+    for h in hits:
+        assert "note_id" in h and "score" in h


### PR DESCRIPTION
## Summary
- implement hybrid local retrieval tool using database notes and `retrieve_candidate_notes`
- return hits with note IDs and placeholder scores, guarding against failures
- add unit test to validate output format

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b54b52fc7483288ac43e6ee3d5e4e0