### PR TITLE
feat: add recipe exploration options

### DIFF
--- a/src/synapse/yaotong/models/recipe.py
+++ b/src/synapse/yaotong/models/recipe.py
@@ -3,16 +3,41 @@ from pydantic import BaseModel, Field
 from typing import Dict, Literal, Optional
 
 class ProviderCfg(BaseModel):
-    type: Literal["local","mcp"]
+    type: Literal["local", "mcp"]
     server: Optional[str] = None
     tool: Optional[str] = None
 
 class Recipe(BaseModel):
-    recipe_id: str
-    mode: Literal["pairwise","fusion"] = "fusion"
-    providers: Dict[str, ProviderCfg] = Field(default_factory=dict)
-    toggles: Dict[str, bool] = Field(default_factory=dict)  # web, kg, redact
-    roots: Dict[str, list] = Field(default_factory=dict)    # filesystem roots for MCP
-    budgets: Dict[str, float] = Field(default_factory=dict) # time_sec/usd/tokens
-    versions: Dict[str, str] = Field(default_factory=dict)  # embed,llm,etc.
-    random_seed: int = 42
+    """Execution configuration for a YaoTong run."""
+
+    recipe_id: str = Field(..., description="Unique identifier for this recipe")
+    mode: Literal["pairwise", "fusion"] = Field(
+        "fusion", description="Orchestration mode for the pipeline"
+    )
+    providers: Dict[str, ProviderCfg] = Field(
+        default_factory=dict, description="Tool provider configurations"
+    )
+    toggles: Dict[str, bool] = Field(
+        default_factory=dict, description="Feature toggles such as web, kg, redact"
+    )
+    roots: Dict[str, list] = Field(
+        default_factory=dict, description="Filesystem roots for MCP servers"
+    )
+    budgets: Dict[str, float] = Field(
+        default_factory=dict, description="Resource budgets (time_sec/usd/tokens)"
+    )
+    versions: Dict[str, str] = Field(
+        default_factory=dict, description="Component versions (embed, llm, etc.)"
+    )
+    random_seed: int = Field(42, description="Random seed for reproducibility")
+    notes_limit: int = Field(5, description="Maximum number of notes to retrieve")
+    explore_depth: int = Field(1, description="Depth of exploration iterations")
+    use_graph: bool = Field(
+        False, description="Whether to trigger the graph module in the pipeline"
+    )
+
+    def __init__(self, **data):
+        # Maintain backwards compatibility with previous `top_k` field.
+        if "top_k" in data and "notes_limit" not in data:
+            data["notes_limit"] = data.pop("top_k")
+        super().__init__(**data)

--- a/src/synapse/yaotong/orchestrator/yaotong.py
+++ b/src/synapse/yaotong/orchestrator/yaotong.py
@@ -36,7 +36,9 @@ class YaoTong:
     async def run(self, goal: str) -> Dict[str, Any]:
         self.wm["goal"] = goal
         # phase 1: retrieval (mocked local tool by default)
-        out = await self.tools["retrieve"].call({"query": goal, "top_k": 10})
+        out = await self.tools["retrieve"].call(
+            {"query": goal, "top_k": self.recipe.notes_limit}
+        )
         self.wm["hits"] = out.get("hits", [])
         # phase 2: (placeholder) hypotheses
         hyps = [{
@@ -48,4 +50,11 @@ class YaoTong:
         # phase 3: fusion compose
         pills = await self.tools["fusion_compose"].call({"hypotheses": hyps})
         self.wm["pills"] = pills.get("pills", [])
-        return {"goal": goal, "pills": self.wm["pills"], "trace": {"hits": self.wm["hits"]}}
+        # optional graph module
+        if self.recipe.use_graph:
+            # placeholder for future graph processing
+            self.wm["graph"] = []
+        trace = {"hits": self.wm["hits"]}
+        if self.recipe.use_graph:
+            trace["graph"] = self.wm["graph"]
+        return {"goal": goal, "pills": self.wm["pills"], "trace": trace}

--- a/tests/test_recipe_model.py
+++ b/tests/test_recipe_model.py
@@ -1,0 +1,22 @@
+from synapse.yaotong.models.recipe import Recipe
+
+
+def test_recipe_defaults_and_serialization():
+    recipe = Recipe(recipe_id="demo")
+    assert recipe.notes_limit == 5
+    assert recipe.explore_depth == 1
+    assert recipe.use_graph is False
+    dumped = recipe.model_dump()
+    assert dumped["notes_limit"] == 5
+    assert dumped["explore_depth"] == 1
+    assert dumped["use_graph"] is False
+
+
+def test_recipe_top_k_backward_compatibility():
+    recipe = Recipe(recipe_id="legacy", top_k=7, use_graph=True, explore_depth=2)
+    assert recipe.notes_limit == 7
+    assert recipe.use_graph is True
+    assert recipe.explore_depth == 2
+    dumped = recipe.model_dump()
+    assert dumped["notes_limit"] == 7
+    assert "top_k" not in dumped


### PR DESCRIPTION
## Summary
- extend Recipe model with note and exploration parameters
- toggle graph processing via recipe.use_graph
- test new Recipe fields and backward compatibility

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b54b5236c48328926a778d02b01ef8